### PR TITLE
Fix/vpc template

### DIFF
--- a/cform/real-time-analytics-spark-streaming-demo.template
+++ b/cform/real-time-analytics-spark-streaming-demo.template
@@ -654,7 +654,7 @@
           "NATInstanceType": "t2.medium",
           "CreateAdditionalPrivateSubnets": "false"
         },
-        "TemplateURL": "https://s3.amazonaws.com/quickstart-reference/aws/vpc/latest/templates/aws-vpc.template"
+        "TemplateURL": "https://aws-quickstart.s3.amazonaws.com/quickstart-aws-vpc/templates/aws-vpc.template"
       }
     },
     "BastionSecurityGroup": {

--- a/cform/real-time-analytics-spark-streaming.template
+++ b/cform/real-time-analytics-spark-streaming.template
@@ -693,7 +693,7 @@
           "NATInstanceType": "t2.medium",
           "CreateAdditionalPrivateSubnets": "false"
         },
-        "TemplateURL": "https://s3.amazonaws.com/quickstart-reference/aws/vpc/latest/templates/aws-vpc.template"
+        "TemplateURL": "https://aws-quickstart.s3.amazonaws.com/quickstart-aws-vpc/templates/aws-vpc.template"
       }
     },
     "BastionSecurityGroup": {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/real-time-analytics-spark-streaming/issues/2

*Description of changes:*
In the master branch, the link to the VPCStackQ template is broken and returns "access denied". Due to this the template cannot be executed. It seems that the location of the template has changed in S3. This PR points to the new location

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
